### PR TITLE
Autocomplete workaround

### DIFF
--- a/src/apis/suggestSearch.js
+++ b/src/apis/suggestSearch.js
@@ -3,7 +3,7 @@ import jsonpAdapter from "axios-jsonp"
 
 export default axios.create({
   baseURL: "https://suggestqueries.google.com/complete/search?",
-  adapter: jsonpAdapter,
+  //adapter: jsonpAdapter,
   params: {
     hl: "en", // Language
     ds: "yt", // Restrict lookup to youtube

--- a/src/components/SearchResult.js
+++ b/src/components/SearchResult.js
@@ -15,9 +15,7 @@ import {
   ListItemText
 } from "@material-ui/core";
 
-const Entities = require("html-entities").XmlEntities;
-
-const entities = new Entities();
+const entities = require("html-entities");
 
 const liVariants = {
   open: {
@@ -57,8 +55,8 @@ const SearchResult = ({ videos }) => {
     // set all the info of current clicked video in this object
     setCurrentVideoSnippet({
       id: video.id.videoId,
-      title: entities.decode(video.snippet.title),
-      channelTitle: entities.decode(video.snippet.channelTitle),
+      title: entities.decode(video.snippet.title, {level: 'xml'}),
+      channelTitle: entities.decode(video.snippet.channelTitle, {level: 'xml'}),
       maxThumbnail: `https://img.youtube.com/vi/${video.id.videoId}/maxresdefault.jpg`,
       sdThumbnail: `https://img.youtube.com/vi/${video.id.videoId}/sddefault.jpg`
       // this is the url of the max resolution of thumbnail
@@ -92,7 +90,7 @@ const SearchResult = ({ videos }) => {
             />
           </ListItemAvatar>
           <ListItemText
-            primary={entities.decode(snippet.title)}
+            primary={entities.decode(snippet.title, {level: 'xml'})}
             secondary={
               <>
                 <Typography

--- a/src/components/header/SearchBox.js
+++ b/src/components/header/SearchBox.js
@@ -69,6 +69,11 @@ const SearchBox = ({ history, location }) => {
     getAutocomplete();
   };
 
+  const processSuggestionResponse = data => {
+    let strData = data.split("window.google.ac.h(")[1].slice(0, -1)
+    return JSON.parse(strData)[1];
+  }
+  
   // get autocomplete data form api
   const getAutocomplete = async () => {
     const response = await suggestSearch.get("", {
@@ -76,7 +81,7 @@ const SearchBox = ({ history, location }) => {
         q: searchQuery
       }
     });
-    setAutoSearch(response.data[1]);
+    setAutoSearch(processSuggestionResponse(response.data));
   };
 
   // get youtube search result from api


### PR DESCRIPTION
Currently, when trying to fetch suggestions, we get error, Uncaught SyntaxError: Unexpected token '<'
This PR has a workaround for that